### PR TITLE
Fixed crash with unloading window

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "resources": {
             "media": [
                 {
-                    "characterRegex": "[0-9 ]",
+                    "characterRegex": "[0-9. ]",
                     "file": "fonts/LCARSGTJ3_58.ttf",
                     "name": "LCARS_58",
                     "targetPlatforms": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "resources": {
             "media": [
                 {
-                    "characterRegex": "[0-9\\.]",
+                    "characterRegex": "[0-9 ]",
                     "file": "fonts/LCARSGTJ3_58.ttf",
                     "name": "LCARS_58",
                     "targetPlatforms": [

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -678,7 +678,7 @@ static void update_time() {
   // Write the current hours and minutes into a buffer
   static char s_buffer[8];
   strftime(s_buffer, sizeof(s_buffer), clock_is_24h_style() ?
-                                          "%H%M" : "%I%M", tick_time);
+                                          "%H%M" : "%l%M", tick_time);
   Current_Min=tick_time->tm_min;
   Current_Hour=tick_time->tm_hour;
   // Display this time on the TextLayer

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -5,7 +5,7 @@
 
 static Window *s_main_window;
 static GFont s_time_font, s_date_font, s_weather_icon_font;
-static TextLayer *s_date_layer, *s_stardate_layer, *s_batterypercent_layer, *s_lifesupport_text_layer, *s_temperature_layer, *s_city_layer, *icon_weather_layer, *s_time_layer, *s_weekname_layer, *s_weeknum_layer, *s_weatherdescript_layer, *s_qt_layer;
+static TextLayer *s_date_layer, *s_stardate_layer, *s_batterypercent_layer, *s_lifesupport_text_layer, *s_temperature_layer, *s_city_layer, *icon_weather_layer, *s_time_layer, *s_weekname_layer, *s_weeknum_layer, *s_weatherdescript_layer;
 static BitmapLayer *s_enterprise_layer;
 static GBitmap *s_enterprise_bitmap;
 static char api_key[50];
@@ -481,13 +481,6 @@ static void window_load(Window *window) {
   layer_set_update_proc(s_bt_layer, bt_update_proc);
   layer_add_child(window_layer, s_bt_layer);
   
-  s_qt_layer = text_layer_create(GRect(3,bounds.size.h-(bounds.size.h/12+10)-22,bounds.size.w/6-3,19));
-  text_layer_set_font(s_qt_layer, fonts_get_system_font(FONT_KEY_GOTHIC_14));
-  text_layer_set_background_color(s_qt_layer, GColorClear);
-  text_layer_set_text_color(s_qt_layer, GColorBlack);
-  text_layer_set_text_alignment(s_qt_layer, GTextAlignmentCenter);
-  layer_add_child(window_layer, text_layer_get_layer(s_qt_layer));
-  
   // Create GFonts
   s_date_font = fonts_load_custom_font(resource_get_handle(RESOURCE_ID_LCARS_32));
   s_time_font = fonts_load_custom_font(resource_get_handle(RESOURCE_ID_LCARS_58));
@@ -756,17 +749,9 @@ static void update_steps(){
   }
 }
 
-static void update_qt(){
-  if (quiet_time_is_active()) {
-    text_layer_set_text(s_qt_layer, "QT");}
-  else {
-    text_layer_set_text(s_qt_layer, " ");}
-}
-
 static void watchface_refresh(){
   update_steps();
   update_time();
-  update_qt();
   if ((strlen(ReplacementWeatherMessage)==0)&&(connection_service_peek_pebble_app_connection()==S_TRUE)) {
     generic_weather_fetch(weather_callback);
   } else {
@@ -802,7 +787,6 @@ static void tick_handler(struct tm *tick_time, TimeUnits units_changed) {
   if (!Watchface_Hibernate && !Watchface_Sleep) {  //if we are no sleeping or hibernating
     if (tick_time->tm_sec==0) { update_steps(); }
     update_time();
-    update_qt();
     
     //every 30 minutes do the following
     if ((tick_time->tm_min % 30 == 0)&&(tick_time->tm_sec==0)) {  
@@ -1107,7 +1091,6 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     update_steps();
 //    APP_LOG(APP_LOG_LEVEL_DEBUG, "Inbox Updating time");
     update_time();
-    update_qt();
     if (strlen(ReplacementWeatherMessage)==0) {
       if (WeatherSetupStatusKey&&WeatherSetupStatusProvider&&WeatherReadyRecieved) {
 //        APP_LOG(APP_LOG_LEVEL_DEBUG, "Calling Weather");
@@ -1154,7 +1137,6 @@ static void window_unload(Window *window) {
   text_layer_destroy(s_weeknum_layer);
   text_layer_destroy(s_weekname_layer);
   text_layer_destroy(s_weatherdescript_layer);
-  text_layer_destroy(s_qt_layer);
   
   // Unload GFont
   fonts_unload_custom_font(s_time_font);
@@ -1221,7 +1203,6 @@ static void init() {
   // Make sure the time and steps are displayed from the start
   update_steps();
   update_time();
-  update_qt();
 
   // Register for battery level updates
   events_battery_state_service_subscribe(battery_callback);

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -5,7 +5,7 @@
 
 static Window *s_main_window;
 static GFont s_time_font, s_date_font, s_weather_icon_font;
-static TextLayer *s_date_layer, *s_stardate_layer, *s_batterypercent_layer, *s_lifesupport_text_layer, *s_temperature_layer, *s_city_layer, *icon_weather_layer, *s_time_layer, *s_weekname_layer, *s_weeknum_layer, *s_weatherdescript_layer;
+static TextLayer *s_date_layer, *s_stardate_layer, *s_batterypercent_layer, *s_lifesupport_text_layer, *s_temperature_layer, *s_city_layer, *icon_weather_layer, *s_time_layer, *s_weekname_layer, *s_weeknum_layer, *s_weatherdescript_layer, *s_qt_layer;
 static BitmapLayer *s_enterprise_layer;
 static GBitmap *s_enterprise_bitmap;
 static char api_key[50];
@@ -481,6 +481,13 @@ static void window_load(Window *window) {
   layer_set_update_proc(s_bt_layer, bt_update_proc);
   layer_add_child(window_layer, s_bt_layer);
   
+  s_qt_layer = text_layer_create(GRect(3,bounds.size.h-(bounds.size.h/12+10)-22,bounds.size.w/6-3,19));
+  text_layer_set_font(s_qt_layer, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+  text_layer_set_background_color(s_qt_layer, GColorClear);
+  text_layer_set_text_color(s_qt_layer, GColorBlack);
+  text_layer_set_text_alignment(s_qt_layer, GTextAlignmentCenter);
+  layer_add_child(window_layer, text_layer_get_layer(s_qt_layer));
+  
   // Create GFonts
   s_date_font = fonts_load_custom_font(resource_get_handle(RESOURCE_ID_LCARS_32));
   s_time_font = fonts_load_custom_font(resource_get_handle(RESOURCE_ID_LCARS_58));
@@ -749,9 +756,17 @@ static void update_steps(){
   }
 }
 
+static void update_qt(){
+  if (quiet_time_is_active()) {
+    text_layer_set_text(s_qt_layer, "QT");}
+  else {
+    text_layer_set_text(s_qt_layer, " ");}
+}
+
 static void watchface_refresh(){
   update_steps();
   update_time();
+  update_qt();
   if ((strlen(ReplacementWeatherMessage)==0)&&(connection_service_peek_pebble_app_connection()==S_TRUE)) {
     generic_weather_fetch(weather_callback);
   } else {
@@ -787,6 +802,7 @@ static void tick_handler(struct tm *tick_time, TimeUnits units_changed) {
   if (!Watchface_Hibernate && !Watchface_Sleep) {  //if we are no sleeping or hibernating
     if (tick_time->tm_sec==0) { update_steps(); }
     update_time();
+    update_qt();
     
     //every 30 minutes do the following
     if ((tick_time->tm_min % 30 == 0)&&(tick_time->tm_sec==0)) {  
@@ -1091,6 +1107,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     update_steps();
 //    APP_LOG(APP_LOG_LEVEL_DEBUG, "Inbox Updating time");
     update_time();
+    update_qt();
     if (strlen(ReplacementWeatherMessage)==0) {
       if (WeatherSetupStatusKey&&WeatherSetupStatusProvider&&WeatherReadyRecieved) {
 //        APP_LOG(APP_LOG_LEVEL_DEBUG, "Calling Weather");
@@ -1137,6 +1154,7 @@ static void window_unload(Window *window) {
   text_layer_destroy(s_weeknum_layer);
   text_layer_destroy(s_weekname_layer);
   text_layer_destroy(s_weatherdescript_layer);
+  text_layer_destroy(s_qt_layer);
   
   // Unload GFont
   fonts_unload_custom_font(s_time_font);
@@ -1203,6 +1221,7 @@ static void init() {
   // Make sure the time and steps are displayed from the start
   update_steps();
   update_time();
+  update_qt();
 
   // Register for battery level updates
   events_battery_state_service_subscribe(battery_callback);

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -18,7 +18,7 @@ static int loweracrossline = 90, upperacrossline = 50, textleft = 25, watchwidth
 static PropertyAnimation *image_property_animation; //1800000
 static bool WeatherSetupStatusKey = S_FALSE, WeatherSetupStatusProvider = S_FALSE, WeatherReadyRecieved = S_FALSE, HibernateEnable = S_TRUE, SleepEnable = S_TRUE;
 GColor text_color;
-static EventHandle s_health_event_handle, s_tick_timer_event_handle;//, s_idle_timer_event_handle;
+static EventHandle s_health_event_handle=NULL, s_tick_timer_event_handle=NULL;//, s_idle_timer_event_handle;
 
 static void read_persist()
 {
@@ -1023,7 +1023,9 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
 		HibernateEnable = data->value->int32 == 1;
 
     //register to recieve significant updates of which we are looking for sleep updates
-    events_health_service_events_unsubscribe(s_health_event_handle);
+    if (s_health_event_handle != NULL) {
+      events_health_service_events_unsubscribe(s_health_event_handle);
+    }
     if (SleepEnable||HibernateEnable) {
       s_health_event_handle = events_health_service_events_subscribe(prv_health_event_handler, NULL);
     }
@@ -1159,8 +1161,12 @@ static void window_unload(Window *window) {
   //unsubscribe from services
   events_battery_state_service_unsubscribe(battery_callback);
   events_connection_service_unsubscribe(bluetooth_callback);
-  events_tick_timer_service_unsubscribe(tick_handler);
-  events_health_service_events_unsubscribe(s_health_event_handle);
+  if (s_tick_timer_event_handle!=NULL) {
+    events_tick_timer_service_unsubscribe(s_tick_timer_event_handle);
+  }
+  if (s_health_event_handle != NULL) {
+    events_health_service_events_unsubscribe(s_health_event_handle);
+  }
   events_app_message_unsubscribe(inbox_received_callback);
   events_app_message_unsubscribe(inbox_dropped_callback);
   events_app_message_unsubscribe(outbox_failed_callback);


### PR DESCRIPTION
If both power saving options are off, the watchface will crash when unloading,
because it tries to unsubscribe from the health service events, but it never
subscribed in the first place!

Also fixed unsubscribing from the tick timer service, since the wrong parameter was passed to unsubscribe when unloading the window, and it wasn't protected by a NULL pointer check (it shouldn't be NULL, but just in case, it's better to check).